### PR TITLE
fix: correct IMAGE input type case in example node template

### DIFF
--- a/{{cookiecutter.project_slug}}/custom-nodes-template/src/{{cookiecutter.project_slug}}/nodes.py
+++ b/{{cookiecutter.project_slug}}/custom-nodes-template/src/{{cookiecutter.project_slug}}/nodes.py
@@ -49,7 +49,7 @@ class Example:
         """
         return {
             "required": {
-                "image": ("Image", { "tooltip": "This is an image"}),
+                "image": ("IMAGE", { "tooltip": "This is an image"}),
                 "int_field": ("INT", {
                     "default": 0,
                     "min": 0, #Minimum value


### PR DESCRIPTION
## Summary

- Fixes a typo in the generated `nodes.py` template: `"Image"` → `"IMAGE"` on the image input type

## Root Cause

The ComfyUI backend (`comfy_execution/validation.py`) performs exact string comparison when validating node input types at runtime. The frontend (`LiteGraphGlobal.ts`) normalizes types with `.toLowerCase()` before checking connections, so the wrong case passes UI validation but fails at execution time.

**Effect on users:** Load Image → Example Node connects fine in the canvas, but clicking Run throws `Return type mismatch between linked nodes` — a misleading error for new custom node developers.

## Test
before
<img width="1054" height="899" alt="Screenshot 2026-05-11 at 11 17 28 PM" src="https://github.com/user-attachments/assets/fba8beb1-f762-4321-8aec-b33b44d72d9c" />

after
<img width="1077" height="533" alt="Screenshot 2026-05-12 at 1 00 21 AM" src="https://github.com/user-attachments/assets/b8462be2-1f04-4fe5-9fd6-464e8e7e023a" />
