### PR TITLE
fix: add missing app import in example.js

### DIFF
--- a/{{cookiecutter.project_slug}}/custom-nodes-template/web/js/example.js
+++ b/{{cookiecutter.project_slug}}/custom-nodes-template/web/js/example.js
@@ -1,1 +1,2 @@
+import { app } from "../../scripts/app.js";
 console.log(app);


### PR DESCRIPTION
## Problem

The JS template is broken out of the box.
Whenever someone spins up a new node using this template and hits ComfyUI, the browser console immediately throws a `ReferenceError: app is not defined`. The entire `example.js` file just dies right there. None of the extension logic—node registration, UI tweaks, event listeners—actually runs.
